### PR TITLE
Move over entirely to the new Actions YAML syntax

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,5 @@
 FROM alpine:latest
 
-LABEL "com.github.actions.name"="Cloudflare Purge Cache"
-LABEL "com.github.actions.description"="Purge a zone's cache via the Cloudflare API"
-LABEL "com.github.actions.icon"="trash-2"
-LABEL "com.github.actions.color"="orange"
-
-LABEL version="0.2.0"
-LABEL repository="https://github.com/jakejarvis/cloudflare-purge-action"
-LABEL homepage="https://jarv.is/"
-LABEL maintainer="Jake Jarvis <jake@jarv.is>"
-
 RUN apk update && apk add openssl curl
 
 ADD entrypoint.sh /entrypoint.sh

--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ All sensitive variables should be [set as encrypted secrets](https://help.github
 
 | Key | Value | Suggested Type | Required |
 | ------------- | ------------- | ------------- | ------------- |
-| `CLOUDFLARE_ZONE` | The Zone ID of your domain, which can be found in the right sidebar of your domain's overview page on the Cloudflare dashboard. For example, `xyz321xyz321xyz321xyz321xyz321xy`. | `secret` | **Yes** |
-| `CLOUDFLARE_EMAIL` | The email address you registered your Cloudflare account with. For example, `me@example.com`. | `secret` | **Yes** |
-| `CLOUDFLARE_KEY` | Your Cloudflare API key, which can be generated using [these instructions](https://support.cloudflare.com/hc/en-us/articles/200167836-Where-do-I-find-my-Cloudflare-API-key-). For example, `abc123abc123abc123abc123abc123abc123abc123abc`. | `secret` | **Yes** |
+| `cloudflareZone` | The Zone ID of your domain, which can be found in the right sidebar of your domain's overview page on the Cloudflare dashboard. For example, `xyz321xyz321xyz321xyz321xyz321xy`. | `secret` | **Yes** |
+| `cloudflareEmail` | The email address you registered your Cloudflare account with. For example, `me@example.com`. | `secret` | **Yes** |
+| `cloudflareKey` | Your Cloudflare API key, which can be generated using [these instructions](https://support.cloudflare.com/hc/en-us/articles/200167836-Where-do-I-find-my-Cloudflare-API-key-). For example, `abc123abc123abc123abc123abc123abc123abc123abc`. | `secret` | **Yes** |
 | `PURGE_URLS` | **Optional.** An array of **fully qualified URLs** to purge. For example: `["https://jarv.is/style.css", "https://jarv.is/favicon.ico"]`. If unset, the action will purge everything (which is [suggested](#purging-specific-files)). | `env` | No |
 
 ### `workflow.yml` Example

--- a/README.md
+++ b/README.md
@@ -35,10 +35,10 @@ jobs:
 
     - name: Purge cache
       uses: jakejarvis/cloudflare-purge-action@master
-      env:
-        CLOUDFLARE_ZONE: ${{ secrets.CLOUDFLARE_ZONE }}
-        CLOUDFLARE_EMAIL: ${{ secrets.CLOUDFLARE_EMAIL }}
-        CLOUDFLARE_KEY: ${{ secrets.CLOUDFLARE_KEY }}
+      with:
+        cloudflareZone: ${{ secrets.CLOUDFLARE_ZONE }}
+        cloudflareEmail: ${{ secrets.CLOUDFLARE_EMAIL }}
+        cloudflareKey: ${{ secrets.CLOUDFLARE_KEY }}
 ```
 
 ### Purging specific files
@@ -46,7 +46,8 @@ jobs:
 To purge only specific files, you can pass an array of **fully qualified URLs** via a fourth environment variable named `PURGE_URLS`. Unfortunately, Cloudflare doesn't support wildcards (unless you're on the insanely expensive Enterprise plan) so in order to purge a folder, you'd need to list every file in that folder. It's probably safer to leave this out and purge everything, but in case you want really to, the syntax is as follows:
 
 ```yaml
-PURGE_URLS: '["https://jarv.is/style.css", "https://jarv.is/favicon.ico"]'
+env:
+  PURGE_URLS: '["https://jarv.is/style.css", "https://jarv.is/favicon.ico"]'
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ All sensitive variables should be [set as encrypted secrets](https://help.github
 | `cloudflareZone` | The Zone ID of your domain, which can be found in the right sidebar of your domain's overview page on the Cloudflare dashboard. For example, `xyz321xyz321xyz321xyz321xyz321xy`. | `secret` | **Yes** |
 | `cloudflareEmail` | The email address you registered your Cloudflare account with. For example, `me@example.com`. | `secret` | **Yes** |
 | `cloudflareKey` | Your Cloudflare API key, which can be generated using [these instructions](https://support.cloudflare.com/hc/en-us/articles/200167836-Where-do-I-find-my-Cloudflare-API-key-). For example, `abc123abc123abc123abc123abc123abc123abc123abc`. | `secret` | **Yes** |
-| `PURGE_URLS` | **Optional.** An array of **fully qualified URLs** to purge. For example: `["https://jarv.is/style.css", "https://jarv.is/favicon.ico"]`. If unset, the action will purge everything (which is [suggested](#purging-specific-files)). | `env` | No |
+| `purgeURLs` | **Optional.** An array of **fully qualified URLs** to purge. For example: `'["https://jarv.is/style.css", "https://jarv.is/favicon.ico"]'`. If unset, the action will purge everything (which is [suggested](#purging-specific-files)). | `option` | No |
 
 ### `workflow.yml` Example
 
@@ -46,8 +46,7 @@ jobs:
 To purge only specific files, you can pass an array of **fully qualified URLs** via a fourth environment variable named `PURGE_URLS`. Unfortunately, Cloudflare doesn't support wildcards (unless you're on the insanely expensive Enterprise plan) so in order to purge a folder, you'd need to list every file in that folder. It's probably safer to leave this out and purge everything, but in case you want really to, the syntax is as follows:
 
 ```yaml
-env:
-  PURGE_URLS: '["https://jarv.is/style.css", "https://jarv.is/favicon.ico"]'
+purgeURLs: '["https://jarv.is/style.css", "https://jarv.is/favicon.ico"]'
 ```
 
 

--- a/action.yml
+++ b/action.yml
@@ -11,6 +11,9 @@ inputs:
   cloudflareKey:
     description: "Your Cloudflare API key."
     required: true
+  purgeURLs:
+    description: "The specific URLs to purge (a STRING in JSON format '["https://jarv.is/style.css", "https://jarv.is/favicon.ico"]')"
+    required: false
 runs:
   using: docker
   image: Dockerfile

--- a/action.yml
+++ b/action.yml
@@ -1,6 +1,16 @@
 name: "Cloudflare Purge Cache"
 description: "Purge a zone's cache via the Cloudflare API"
 author: jakejarvis
+inputs:
+  cloudflareZone:
+    description: "The Zone ID of your domain, which can be found in the right sidebar of your domain's overview page on the Cloudflare dashboard."
+    required: true
+  cloudflareEmail:
+    description: "The email address you registered your Cloudflare account with."
+    required: true
+  cloudflareKey:
+    description: "Your Cloudflare API key."
+    required: true
 runs:
   using: docker
   image: Dockerfile

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,18 +2,18 @@
 
 set -e
 
-if [ -z "$CLOUDFLARE_ZONE" ]; then
-  echo "CLOUDFLARE_ZONE is not set. Quitting."
+if [ -z "$INPUT_CLOUDFLAREZONE" ]; then
+  echo "cloudflareZone is not set. Quitting."
   exit 1
 fi
 
-if [ -z "$CLOUDFLARE_EMAIL" ]; then
-  echo "CLOUDFLARE_EMAIL is not set. Quitting."
+if [ -z "$INPUT_CLOUDFLAREEMAIL" ]; then
+  echo "cloudflareEmail is not set. Quitting."
   exit 1
 fi
 
-if [ -z "$CLOUDFLARE_KEY" ]; then
-  echo "CLOUDFLARE_KEY is not set. Quitting."
+if [ -z "$INPUT_CLOUDFLAREKEY" ]; then
+  echo "cloudflareKey is not set. Quitting."
   exit 1
 fi
 
@@ -25,9 +25,9 @@ else
 fi
 
 # Call the API and store the response for later.
-HTTP_RESPONSE=$(curl -sS -X POST "https://api.cloudflare.com/client/v4/zones/${CLOUDFLARE_ZONE}/purge_cache" \
-                     -H "X-Auth-Email: ${CLOUDFLARE_EMAIL}" \
-                     -H "X-Auth-Key: ${CLOUDFLARE_KEY}" \
+HTTP_RESPONSE=$(curl -sS -X POST "https://api.cloudflare.com/client/v4/zones/${INPUT_CLOUDFLAREZONE}/purge_cache" \
+                     -H "X-Auth-Email: ${INPUT_CLOUDFLAREEMAIL}" \
+                     -H "X-Auth-Key: ${INPUT_CLOUDFLAREKEY}" \
                      -H "Content-Type: application/json" \
                      -w "HTTP_STATUS:%{http_code}" \
                      "$@")

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -18,8 +18,8 @@ if [ -z "$INPUT_CLOUDFLAREKEY" ]; then
 fi
 
 # If URL array is passed, only purge those. Otherwise, purge everything.
-if [ -n "$PURGE_URLS" ]; then
-  set -- --data '{"files":'"${PURGE_URLS}"'}'
+if [ -n "$INPUT_PURGEURLS" ]; then
+  set -- --data '{"files":'"${INPUT_PURGEURLS}"'}'
 else
   set -- --data '{"purge_everything":true}'
 fi


### PR DESCRIPTION
This PR almost entirely removes the need for the `env` section in the workflow config (now it's only needed for `PURGE_URLS`) and transfers everything over to the `with` section (see the modified readme for details).