### PR TITLE
Remove README.md warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # GitHub Action to Purge Cloudflare Cache  🗑️ 
 
-> **⚠️ Note:** To use this action, you must have access to the [GitHub Actions](https://github.com/features/actions) feature. GitHub Actions are currently only available in public beta. You can [apply for the GitHub Actions beta here](https://github.com/features/actions/signup/).
-
 This simple action calls the [Cloudflare API](https://api.cloudflare.com/#zone-purge-all-files) to purge the cache of your website, which can be a helpful last step after deploying a new version.
 
 


### PR DESCRIPTION
This PR is to just remove the GitHub Actions beta warning in the README.md.